### PR TITLE
Implement filename template

### DIFF
--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -6,6 +6,8 @@
 # @Filename: test_camera.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
+import os
+
 import astropy
 import astropy.io.fits
 import numpy
@@ -115,3 +117,13 @@ async def test_connect_uid_warning(camera):
 
     with pytest.warns(CameraWarning):
         await camera.connect(force=True)
+
+
+async def test_expose_no_filename(camera):
+
+    exposure = await camera.expose(1.0)
+
+    assert exposure.filename is not None
+
+    exposure.write()
+    assert os.path.exists(exposure.filename)

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -9,6 +9,7 @@
 import pytest
 
 from basecam.exceptions import ExposureError
+from basecam.exposure import ImageNamer
 
 
 def test_exposure_no_model(exposure):
@@ -55,3 +56,30 @@ def test_obstime_str(exposure):
     exposure.obstime = test_date
 
     assert exposure.obstime.utc.iso == test_date
+
+
+def test_image_namer(tmp_path):
+
+    image_namer = ImageNamer('test_{num:04d}.fits', dirname=tmp_path)
+
+    assert image_namer.counter == 1
+    assert image_namer() == tmp_path / 'test_0001.fits'
+
+
+def test_image_namer_overwrite(tmp_path):
+
+    image_namer = ImageNamer('test_{num:04d}.fits', dirname=tmp_path, overwrite=True)
+
+    assert image_namer.counter == 1
+    assert image_namer() == tmp_path / 'test_0001.fits'
+
+
+def test_image_namer_files_exist(tmp_path):
+
+    (tmp_path / 'test_0001.fits').touch()
+    (tmp_path / 'test_0004.fits').touch()
+
+    image_namer = ImageNamer('test_{num:04d}.fits', dirname=tmp_path)
+
+    assert image_namer.counter == 5
+    assert image_namer() == tmp_path / 'test_0005.fits'


### PR DESCRIPTION
Provides a new class, `ImageNamer` that provides sequential image filenames based on a basename template. This can be expanded upon later to create image namers that have more complicated templates (e.g., using attributes from the camera instance) or timestamps.

Closes #3.